### PR TITLE
Add missing header

### DIFF
--- a/src/unsafessl/sslunsaferingbuffer_p.h
+++ b/src/unsafessl/sslunsaferingbuffer_p.h
@@ -55,6 +55,9 @@
 #include <QtCore/qbytearray.h>
 #include <QtCore/qvector.h>
 
+// Add missing climits header for INT_MAX
+#include <climits>
+
 QT_BEGIN_NAMESPACE
 
 #ifndef QRINGBUFFER_CHUNKSIZE


### PR DESCRIPTION
Hello,

When I tried to rebuild the package in Kali I had this error:
```
/<<PKGBUILDDIR>>/src/unsafessl/sslunsaferingbuffer_p.h:57:1: note: ‘INT_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
   56 | #include <QtCore/qvector.h>
  +++ |+#include <climits>
   57 |
```
